### PR TITLE
feat: allow a scope to contain numbers

### DIFF
--- a/src/conventional/commits.rs
+++ b/src/conventional/commits.rs
@@ -92,7 +92,7 @@ impl FromStr for Commit {
                 r#"(?xms)
             ^
             (?P<type>[a-zA-Z]+)
-            (?:\((?P<scope>[a-zA-Z]+(?:-[a-zA-Z]+)*)\))?
+            (?:\((?P<scope>[[:alnum:]]+(?:-[[:alnum:]]+)*)\))?
             (?P<breaking>!)?
             :\x20(?P<desc>[^\r\n]+)
             $"#,
@@ -204,6 +204,23 @@ mod tests {
                 scope: Some("lang".into()),
                 breaking: false,
                 description: "add polish language".into(),
+                body: None,
+                footers: Vec::new()
+            }
+        );
+    }
+
+    #[test]
+    fn test_with_alnum_scope() {
+        let msg = "feat(bar2): add a foo to new bar";
+        let commit: Commit = msg.parse().expect("valid");
+        assert_eq!(
+            commit,
+            Commit {
+                r#type: Type::Feat,
+                scope: Some("bar2".into()),
+                breaking: false,
+                description: "add a foo to new bar".into(),
                 body: None,
                 footers: Vec::new()
             }

--- a/src/conventional/commits.rs
+++ b/src/conventional/commits.rs
@@ -92,7 +92,7 @@ impl FromStr for Commit {
                 r#"(?xms)
             ^
             (?P<type>[a-zA-Z]+)
-            (?:\((?P<scope>[[:alnum:]]+(?:-[[:alnum:]]+)*)\))?
+            (?:\((?P<scope>[[:alnum:]]+(?:[-_/][[:alnum:]]+)*)\))?
             (?P<breaking>!)?
             :\x20(?P<desc>[^\r\n]+)
             $"#,
@@ -211,14 +211,14 @@ mod tests {
     }
 
     #[test]
-    fn test_with_alnum_scope() {
-        let msg = "feat(bar2): add a foo to new bar";
+    fn test_with_complex_scope() {
+        let msg = "feat(bar2/a_b-C4): add a foo to new bar";
         let commit: Commit = msg.parse().expect("valid");
         assert_eq!(
             commit,
             Commit {
                 r#type: Type::Feat,
-                scope: Some("bar2".into()),
+                scope: Some("bar2/a_b-C4".into()),
                 breaking: false,
                 description: "add a foo to new bar".into(),
                 body: None,


### PR DESCRIPTION
The spec is quite vague as to what characters are allowed in a scope. It looks like the Javascript implementation is very loose (https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/index.js#L10) - allowing spaces, $, . and general word chars. Not sure how wide to cast it, but I had a use-case where a scope included digits and that seems fairly reasonable to allow?

Thanks for this tool, great to have a simple executable and not have to deal with npm installs!